### PR TITLE
Add frame repositioning

### DIFF
--- a/Arcade-Bagman.sv
+++ b/Arcade-Bagman.sv
@@ -202,12 +202,20 @@ wire [1:0] ar = status[20:19];
 assign VIDEO_ARX = (!ar) ? ((status[2]|mod_squa)  ? 8'd4 : 8'd3) : (ar - 1'd1);
 assign VIDEO_ARY = (!ar) ? ((status[2]|mod_squa)  ? 8'd3 : 8'd4) : 12'd0;
 
+// Used status bits
+// 00000000001111111111222222222233
+// 01234567890123456789012345678901
+// 0123456789abcdefghijklmnopqrstuv
+//   xxxxxxxxxxxxxx   xxxx    x    
+
 `include "build_id.v" 
 localparam CONF_STR = {
 	"A.BAGMAN;;",
 	"H0OJK,Aspect ratio,Original,Full Screen,[ARC1],[ARC2];",
 	"H1H0O2,Orientation,Vert,Horz;",
 	"O35,Scandoubler Fx,None,HQ2x,CRT 25%,CRT 50%,CRT 75%;",
+	"O8B,Analog Video H-Pos,0,-1,-2,-3,-4,-5,-6,-7,8,7,6,5,4,3,2,1;",
+  "OCF,Analog Video V-Pos,0,-1,-2,-3,-4,-5,-6,-7,8,7,6,5,4,3,2,1;",
 	"h2OR,Autosave Hiscores,Off,On;",
 	"-;",
 	"DIP;",
@@ -366,6 +374,8 @@ arcade_video #(256,8) arcade_video
 	.fx(status[5:3])
 );
 
+wire [3:0] hoffset = status[11:8];
+wire [3:0] voffset = status[15:12];
 
 wire [12:0] audio;
 assign AUDIO_L = {audio, 3'b000};
@@ -442,6 +452,8 @@ bagman bagman
 	.video_vs(vs),
 	.hblank(hblank),
 	.vblank(vblank),
+  .hoffset(hoffset),
+  .voffset(voffset),
 
 	.mod_pick(mod_pick|mod_squa|mod_botanic),
 

--- a/bagman.vhd
+++ b/bagman.vhd
@@ -15,11 +15,12 @@ port(
 	video_g      : out std_logic_vector(2 downto 0);
 	video_b      : out std_logic_vector(1 downto 0);
 	video_clk    : out std_logic;
-	video_csync  : out std_logic;
 	video_hs     : out std_logic;
 	video_vs     : out std_logic;
 	hblank       : out std_logic;
 	vblank       : out std_logic;
+  hoffset      : in std_logic_vector(3 downto 0);
+  voffset      : in std_logic_vector(3 downto 0);
 	vce          : out std_logic;
 
 	mod_pick     : in std_logic;
@@ -50,7 +51,6 @@ architecture struct of bagman is
 -- video syncs
 signal hsync       : std_logic;
 signal vsync       : std_logic;
-signal csync       : std_logic;
 
 -- global synchronisation
 signal addr_state : std_logic_vector(3 downto 0);
@@ -141,7 +141,6 @@ video_r     <= do_palette(2 downto 0);
 video_g     <= do_palette(5 downto 3);
 video_b     <= do_palette(7 downto 6);
 video_clk   <= clock_12mhz;
-video_csync <= csync;
 video_hs    <= hsync;
 video_vs    <= vsync;
 
@@ -407,9 +406,10 @@ port map (
 	clock_12mhz => clock_12mhz,
 	hsync   => hsync,
 	vsync   => vsync,
-	csync   => csync,
 	hblank  => hblank,
 	vblank  => vblank,
+  hoffset => hoffset,
+  voffset => voffset,
 	vce     => vce,
 
 	addr_state => addr_state,

--- a/video_gen.vhd
+++ b/video_gen.vhd
@@ -9,9 +9,10 @@ port(
 	clock_12mhz : in std_logic;
 	hsync       : out std_logic;
 	vsync       : out std_logic;
-	csync       : out std_logic;
 	hblank      : out std_logic;
 	vblank      : out std_logic;
+  hoffset     : in std_logic_vector(3 downto 0);
+  voffset     : in std_logic_vector(3 downto 0);
 	vce         : out std_logic;
 
 	addr_state  : out std_logic_vector(3 downto 0);
@@ -31,9 +32,9 @@ signal hcnt    : unsigned (8 downto 0) := to_unsigned(511,9);
 signal vcnt    : unsigned (8 downto 0) := to_unsigned(511,9);
 signal vcnt_r  : unsigned (8 downto 0) := to_unsigned(511,9);
 
+signal hoff    : integer range -8 to 7;
+signal voff    : integer range -8 to 7;
 signal hsync0  : std_logic;
-signal hsync1  : std_logic;
-signal hsync2  : std_logic;
 
 signal enable_clk : std_logic := '0';
 
@@ -47,7 +48,8 @@ y_tile     <= std_logic_vector(vcnt_r(7 downto 3));
 x_pixel    <= std_logic_vector(hcnt(2 downto 0));
 y_pixel    <= std_logic_vector(vcnt_r(2 downto 0));
 
-hsync <= hsync0;
+hoff       <= to_integer(signed(hoffset));
+voff       <= to_integer(signed(voffset));
 
 -- Compteur horizontal : 511-128+1=384 pixels
 -- 128 à 175 :  48 pixels fin de ligne 
@@ -81,7 +83,7 @@ begin
 				hcnt <= hcnt + 1;
 			end if; 
 
-			if hcnt = 175 then
+			if hcnt = to_unsigned((175+ hoff),9) then
 				if vcnt = 511 then
 					vcnt <= to_unsigned(248,9);
 				else
@@ -89,34 +91,17 @@ begin
 				end if;
 			end if;
 
-			if    hcnt = (175+ 0) then hsync0 <= '0';
-			elsif hcnt = (175+29) then hsync0 <= '1';
+			if    hcnt = to_unsigned((175+ hoff),9) then hsync <= '0';
+			elsif hcnt = to_unsigned((175+ hoff+ 29),9) then hsync <= '1';
 			end if;    
 
-			if    hcnt = (175)        then hsync1 <= '0';
-			elsif hcnt = (175+13)     then hsync1 <= '1';
-			elsif hcnt = (175   +192) then hsync1 <= '0';
-			elsif hcnt = (175+13+192) then hsync1 <= '1';
-			end if;    
-
-			if    hcnt = (175)       then hsync2 <= '0';
-			elsif hcnt = (175-28)    then hsync2 <= '1';
-			end if;    
-
-			if    vcnt = 509 then csync <= hsync1;
-			elsif vcnt = 510 then csync <= hsync1;
-			elsif vcnt = 511 then csync <= hsync1;
-			elsif vcnt = 248 then csync <= hsync2;
-			elsif vcnt = 249 then csync <= hsync2;
-			elsif vcnt = 250 then csync <= hsync2;
-			elsif vcnt = 251 then csync <= hsync1;
-			elsif vcnt = 252 then csync <= hsync1;
-			elsif vcnt = 253 then csync <= hsync1;
-			else                  csync <= hsync0; 
-			end if;
-
-			if    vcnt = 511 then vsync <= '0';
-			elsif vcnt = 250 then vsync <= '1';
+      -- Turn sync on - could be at the end of this frame or the start of the next
+			if    vcnt = to_unsigned(511+ voff,9) then vsync <= '0';
+			elsif vcnt = to_unsigned(247+ voff,9) then vsync <= '0';
+      -- Similarly, turn it off. The offsets may underflow or overflow, but
+      -- will be correct.
+			elsif vcnt = to_unsigned(512+ voff,9) then vsync <= '1';
+			elsif vcnt = to_unsigned(250+ voff,9) then vsync <= '1';
 			end if;    
 
 			if    hcnt = (127+8+1) then hblank <= '1'; -- +8 = retard du shift_register + 1 pixel


### PR DESCRIPTION
This commit adds the ability to reposition the analog video frame.
It also gets rid of the composite sync signal, which was never
used.